### PR TITLE
Add savings goals and trends

### DIFF
--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -144,3 +144,70 @@ def update_category(db: Session, category_id: int, category_update: str):
     db.commit()
     db.refresh(category)
     return category
+
+# CRUD for Savings Goals
+def create_savings_goal(db: Session, goal: schemas.SavingsGoalCreate):
+    db_goal = models.SavingsGoal(**goal.dict())
+    db.add(db_goal)
+    db.commit()
+    db.refresh(db_goal)
+    return db_goal
+
+def get_savings_goals(db: Session, skip: int = 0, limit: int = 10):
+    return db.query(models.SavingsGoal).offset(skip).limit(limit).all()
+
+def get_savings_goal(db: Session, goal_id: int):
+    goal = db.query(models.SavingsGoal).filter(models.SavingsGoal.id == goal_id).first()
+    if not goal:
+        raise HTTPException(status_code=404, detail="Savings goal not found")
+    return goal
+
+def update_savings_goal(db: Session, goal_id: int, goal_update: schemas.SavingsGoalCreate):
+    goal = get_savings_goal(db, goal_id)
+    for key, value in goal_update.dict().items():
+        setattr(goal, key, value)
+    db.commit()
+    db.refresh(goal)
+    return goal
+
+def delete_savings_goal(db: Session, goal_id: int):
+    goal = get_savings_goal(db, goal_id)
+    db.delete(goal)
+    db.commit()
+    return {"detail": "Savings goal deleted successfully"}
+
+
+def expenses_by_month(db: Session):
+    results = (
+        db.query(
+            models.Expense.date,
+            models.Expense.amount,
+        )
+        .all()
+    )
+    summary = {}
+    for date, amount in results:
+        key = date.strftime("%Y-%m")
+        summary[key] = summary.get(key, 0) + amount
+    return summary
+
+
+def expenses_by_category(db: Session):
+    results = (
+        db.query(models.Expense.category, models.Expense.amount).all()
+    )
+    summary = {}
+    for category, amount in results:
+        summary[category] = summary.get(category, 0) + amount
+    return summary
+
+
+def expenses_daily(db: Session):
+    results = (
+        db.query(models.Expense.date, models.Expense.amount).all()
+    )
+    summary = {}
+    for date, amount in results:
+        key = date.strftime("%Y-%m-%d")
+        summary[key] = summary.get(key, 0) + amount
+    return summary

--- a/backend/app/endpoints/__init__.py
+++ b/backend/app/endpoints/__init__.py
@@ -1,1 +1,9 @@
-# Placeholder for __init__.py
+from fastapi import APIRouter
+from . import expenses, budgets, categories, goals
+
+
+api_router = APIRouter()
+api_router.include_router(expenses.router)
+api_router.include_router(budgets.router)
+api_router.include_router(categories.router)
+api_router.include_router(goals.router)

--- a/backend/app/endpoints/expenses.py
+++ b/backend/app/endpoints/expenses.py
@@ -37,3 +37,18 @@ def read_expense_history(expense_id: int, db: Session = Depends(get_db)):
 def generate_recurring(confirm: bool = False, db: Session = Depends(get_db)):
     return crud.generate_recurring_expenses(db=db, confirm=confirm)
 
+
+@router.get("/expenses/summary/monthly")
+def summary_monthly(db: Session = Depends(get_db)):
+    return crud.expenses_by_month(db)
+
+
+@router.get("/expenses/summary/category")
+def summary_category(db: Session = Depends(get_db)):
+    return crud.expenses_by_category(db)
+
+
+@router.get("/expenses/summary/daily")
+def summary_daily(db: Session = Depends(get_db)):
+    return crud.expenses_daily(db)
+

--- a/backend/app/endpoints/goals.py
+++ b/backend/app/endpoints/goals.py
@@ -1,0 +1,26 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+from .. import crud, schemas
+from ..db import get_db
+
+router = APIRouter()
+
+@router.post("/goals/", response_model=schemas.SavingsGoal)
+def create_goal(goal: schemas.SavingsGoalCreate, db: Session = Depends(get_db)):
+    return crud.create_savings_goal(db=db, goal=goal)
+
+@router.get("/goals/", response_model=list[schemas.SavingsGoal])
+def read_goals(skip: int = 0, limit: int = 10, db: Session = Depends(get_db)):
+    return crud.get_savings_goals(db=db, skip=skip, limit=limit)
+
+@router.get("/goals/{goal_id}", response_model=schemas.SavingsGoal)
+def read_goal(goal_id: int, db: Session = Depends(get_db)):
+    return crud.get_savings_goal(db=db, goal_id=goal_id)
+
+@router.put("/goals/{goal_id}", response_model=schemas.SavingsGoal)
+def update_goal(goal_id: int, goal_update: schemas.SavingsGoalCreate, db: Session = Depends(get_db)):
+    return crud.update_savings_goal(db=db, goal_id=goal_id, goal_update=goal_update)
+
+@router.delete("/goals/{goal_id}")
+def delete_goal(goal_id: int, db: Session = Depends(get_db)):
+    return crud.delete_savings_goal(db=db, goal_id=goal_id)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,7 +3,7 @@
 import os
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from .endpoints import expenses, budgets, categories
+from .endpoints import api_router
 from .db import Base  # Import Base from db.py to avoid duplicate Base
 from dotenv import load_dotenv
 
@@ -20,7 +20,4 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-# Include routers for expenses, budgets, and categories
-app.include_router(expenses.router, prefix="/api", tags=["Expenses"])
-app.include_router(budgets.router, prefix="/api", tags=["Budgets"])
-app.include_router(categories.router, prefix="/api", tags=["Categories"])
+app.include_router(api_router, prefix="/api")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -50,3 +50,13 @@ class ExpenseHistory(Base):
     changed_at = Column(DateTime, default=datetime.datetime.utcnow)
 
     expense = relationship("Expense", back_populates="histories")
+
+
+class SavingsGoal(Base):
+    __tablename__ = "savings_goals"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, nullable=False)
+    target_amount = Column(Float, nullable=False)
+    saved_amount = Column(Float, default=0)
+    target_date = Column(DateTime, nullable=False)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -47,3 +47,21 @@ class ExpenseHistory(BaseModel):
 
     class Config:
         from_attributes = True
+
+
+class SavingsGoalCreate(BaseModel):
+    name: constr(strip_whitespace=True, min_length=1)
+    target_amount: float = Field(..., gt=0)
+    saved_amount: float = 0
+    target_date: datetime.datetime
+
+
+class SavingsGoal(BaseModel):
+    id: int
+    name: str
+    target_amount: float
+    saved_amount: float
+    target_date: datetime.datetime
+
+    class Config:
+        from_attributes = True

--- a/backend/tests/test_expenses.py
+++ b/backend/tests/test_expenses.py
@@ -1,11 +1,15 @@
 # Unit Tests for CRUD Operations in Fuyu App
 # Using `pytest` to test the CRUD functionality for the backend
 
+import os
 import pytest
 from sqlalchemy import create_engine
+import datetime
 from sqlalchemy.orm import sessionmaker
+
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
 from backend.app.db import Base, get_db
-from backend.app.models import Expense, Budget, ExpenseHistory
+from backend.app.models import Expense, Budget, ExpenseHistory, SavingsGoal
 from backend.app.crud import (
     create_expense,
     get_expenses,
@@ -14,8 +18,10 @@ from backend.app.crud import (
     update_expense,
     get_expense_history,
     generate_recurring_expenses,
+    create_savings_goal,
+    get_savings_goals,
 )
-from backend.app.schemas import ExpenseCreate, BudgetCreate
+from backend.app.schemas import ExpenseCreate, BudgetCreate, SavingsGoalCreate
 
 # Create an in-memory SQLite database for testing purposes
 test_engine = create_engine("sqlite:///:memory:")
@@ -91,6 +97,14 @@ def test_generate_recurring_expenses(test_db):
     generated = generate_recurring_expenses(test_db, confirm=True)
     assert len(generated) == 1
     assert generated[0].id is not None
+
+
+def test_create_savings_goal(test_db):
+    goal_data = SavingsGoalCreate(name="Trip", target_amount=1000.0, saved_amount=200.0, target_date=datetime.datetime.utcnow())
+    goal = create_savings_goal(test_db, goal_data)
+    goals = get_savings_goals(test_db)
+    assert goal.id is not None
+    assert len(goals) == 1
 
 if __name__ == "__main__":
     pytest.main()

--- a/frontend/fuyu-frontend/package.json
+++ b/frontend/fuyu-frontend/package.json
@@ -11,7 +11,9 @@
     "react-dom": "^18.3.1",
     "react-router-dom": "^7.2.0",
     "react-scripts": "5.0.1",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "chart.js": "^4.4.1",
+    "react-chartjs-2": "^5.2.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/frontend/fuyu-frontend/src/App.js
+++ b/frontend/fuyu-frontend/src/App.js
@@ -4,6 +4,8 @@ import React from 'react';
 import { Route, Routes, Link } from 'react-router-dom';
 import AddData from './pages/AddData';
 import SeeData from './pages/SeeData';
+import Trends from './pages/Trends';
+import Goals from './pages/Goals';
 
 function App() {
   return (
@@ -11,11 +13,15 @@ function App() {
       <h1>Fuyu App</h1>
       <nav style={{ marginBottom: '20px' }}>
         <Link to="/add" style={{ marginRight: '10px' }}>Add Expense</Link>
-        <Link to="/view">See Expenses</Link>
+        <Link to="/view" style={{ marginRight: '10px' }}>See Expenses</Link>
+        <Link to="/trends" style={{ marginRight: '10px' }}>Trends</Link>
+        <Link to="/goals">Goals</Link>
       </nav>
       <Routes>
         <Route path="/add" element={<AddData />} />
         <Route path="/view" element={<SeeData />} />
+        <Route path="/trends" element={<Trends />} />
+        <Route path="/goals" element={<Goals />} />
         <Route path="*" element={<div>Welcome! Choose an option above.</div>} />
       </Routes>
     </div>

--- a/frontend/fuyu-frontend/src/App.test.js
+++ b/frontend/fuyu-frontend/src/App.test.js
@@ -1,8 +1,19 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
+import { MemoryRouter } from 'react-router-dom';
+jest.mock('react-router-dom', () => ({
+  Link: ({children}) => <div>{children}</div>,
+  Routes: ({children}) => <div>{children}</div>,
+  Route: () => null,
+  MemoryRouter: ({children}) => <div>{children}</div>
+}));
 
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+test('renders header', () => {
+  render(
+    <MemoryRouter>
+      <App />
+    </MemoryRouter>
+  );
+  const heading = screen.getByText(/Fuyu App/i);
+  expect(heading).toBeInTheDocument();
 });

--- a/frontend/fuyu-frontend/src/api/expenses.js
+++ b/frontend/fuyu-frontend/src/api/expenses.js
@@ -24,3 +24,18 @@ export const addExpense = async (expenseData) => {
   }
 };
 
+export const getMonthlySummary = async () => {
+  const res = await axios.get(`${BASE_URL}/expenses/summary/monthly`);
+  return res.data;
+};
+
+export const getCategorySummary = async () => {
+  const res = await axios.get(`${BASE_URL}/expenses/summary/category`);
+  return res.data;
+};
+
+export const getDailySummary = async () => {
+  const res = await axios.get(`${BASE_URL}/expenses/summary/daily`);
+  return res.data;
+};
+

--- a/frontend/fuyu-frontend/src/api/goals.js
+++ b/frontend/fuyu-frontend/src/api/goals.js
@@ -1,0 +1,18 @@
+import axios from 'axios';
+
+const BASE_URL = 'http://127.0.0.1:8000/api';
+
+export const getGoals = async () => {
+  const res = await axios.get(`${BASE_URL}/goals/`);
+  return res.data;
+};
+
+export const addGoal = async (goal) => {
+  const res = await axios.post(`${BASE_URL}/goals/`, goal);
+  return res.data;
+};
+
+export const updateGoal = async (id, goal) => {
+  const res = await axios.put(`${BASE_URL}/goals/${id}`, goal);
+  return res.data;
+};

--- a/frontend/fuyu-frontend/src/pages/Goals.js
+++ b/frontend/fuyu-frontend/src/pages/Goals.js
@@ -1,0 +1,53 @@
+import React, { useEffect, useState } from 'react';
+import { getGoals, addGoal } from '../api/goals';
+
+function Goals() {
+  const [goals, setGoals] = useState([]);
+  const [name, setName] = useState('');
+  const [target, setTarget] = useState('');
+  const [date, setDate] = useState('');
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const load = async () => {
+    setGoals(await getGoals());
+  };
+
+  const submit = async e => {
+    e.preventDefault();
+    await addGoal({name, target_amount: parseFloat(target), target_date: date, saved_amount:0});
+    setName('');
+    setTarget('');
+    setDate('');
+    load();
+  };
+
+  return (
+    <div>
+      <h2>Savings Goals</h2>
+      <form onSubmit={submit}>
+        <input placeholder="Name" value={name} onChange={e=>setName(e.target.value)} />
+        <input placeholder="Target" type="number" value={target} onChange={e=>setTarget(e.target.value)} />
+        <input type="date" value={date} onChange={e=>setDate(e.target.value)} />
+        <button type="submit">Add Goal</button>
+      </form>
+      <ul>
+        {goals.map(g => {
+          const pct = (g.saved_amount / g.target_amount) * 100;
+          return (
+            <li key={g.id}>
+              {g.name}: {g.saved_amount}/{g.target_amount}
+              <div style={{background:'#eee', width:'200px'}}>
+                <div style={{width:`${pct}%`, background:'green', color:'white'}}>{pct.toFixed(0)}%</div>
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+
+export default Goals;

--- a/frontend/fuyu-frontend/src/pages/Trends.js
+++ b/frontend/fuyu-frontend/src/pages/Trends.js
@@ -1,0 +1,46 @@
+import React, { useEffect, useState } from 'react';
+import { Bar, Pie } from 'react-chartjs-2';
+import { Chart as ChartJS, CategoryScale, LinearScale, BarElement, ArcElement } from 'chart.js';
+import { getMonthlySummary, getCategorySummary, getDailySummary } from '../api/expenses';
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, ArcElement);
+
+function Trends() {
+  const [monthly, setMonthly] = useState({});
+  const [category, setCategory] = useState({});
+  const [daily, setDaily] = useState({});
+
+  useEffect(() => {
+    const fetchData = async () => {
+      setMonthly(await getMonthlySummary());
+      setCategory(await getCategorySummary());
+      setDaily(await getDailySummary());
+    };
+    fetchData();
+  }, []);
+
+  const monthlyData = {
+    labels: Object.keys(monthly),
+    datasets: [{ label: 'Total', data: Object.values(monthly), backgroundColor: 'rgba(75,192,192,0.4)' }]
+  };
+
+  const categoryData = {
+    labels: Object.keys(category),
+    datasets: [{ data: Object.values(category), backgroundColor: ['#FF6384','#36A2EB','#FFCE56','#4BC0C0'] }]
+  };
+
+  return (
+    <div>
+      <h2>Spending Trends</h2>
+      <div style={{ width:'400px', margin:'20px' }}>
+        <Bar data={monthlyData} />
+      </div>
+      <div style={{ width:'400px', margin:'20px' }}>
+        <Pie data={categoryData} />
+      </div>
+      <pre>{JSON.stringify(daily, null, 2)}</pre>
+    </div>
+  );
+}
+
+export default Trends;


### PR DESCRIPTION
## Summary
- savings goal tracking endpoints and schema
- monthly/category/daily summaries
- simple React pages for spending trends and goals with charts
- tests for new backend features

## Testing
- `PYTHONPATH=. pytest backend/tests/test_expenses.py -q`
- `CI=true npm test --silent` *(fails: Cannot find module 'react-router-dom' from 'src/App.test.js')*

------
https://chatgpt.com/codex/tasks/task_e_6843132d1674832db82f3e1b0f75dcd6